### PR TITLE
Fix a bug: The return type of selectByKeywordsWithRowbounds is constant ('List<Book>') in dao.vm #35

### DIFF
--- a/framework/src/main/resources/fondue/gen/dao.vm
+++ b/framework/src/main/resources/fondue/gen/dao.vm
@@ -17,7 +17,7 @@ public interface ${resourceClassName}Dao {
 
     @SelectProvider(type = SqlProvider.class, method = "findBy")
     @ResultMap("${entityFqcn.replace(".model.", ".dao.")}Mapper.BaseResultMap")
-    List<Book> selectByKeywordsWithRowbounds(@Param("keywords") List<String> keywords, RowBounds rowBounds);
+    List<${entity}> selectByKeywordsWithRowbounds(@Param("keywords") List<String> keywords, RowBounds rowBounds);
 
     public static final class SqlProvider {
         public SqlProvider() {


### PR DESCRIPTION
…nt ('List<Book>') in dao.vm #35